### PR TITLE
Attachments and recipients are removed only when sending via SMTP

### DIFF
--- a/reporting/crashsender/ErrorReportSender.cpp
+++ b/reporting/crashsender/ErrorReportSender.cpp
@@ -2067,20 +2067,25 @@ BOOL CErrorReportSender::SendReport()
         if(0==m_Assync.WaitForCompletion())
         {
             status = 0;
-            break;
+            
+			// If the report was sent through SMTP
+			if (id == CR_SMTP)
+			{
+				// Remove the ZIP and MD5 files from the attachment list
+				m_EmailMsg.RemoveAttachment(0);
+				m_EmailMsg.RemoveAttachment(0);
+
+				// Remove the recipient so that there will be no copies
+				m_EmailMsg.RemoveRecipient(0);
+			}
+			
+			break;
         }
     }
 
     // Remove compressed ZIP file and MD5 file
     Utility::RecycleFile(m_sZipName, true);
     Utility::RecycleFile(m_sZipName+_T(".md5"), true);
-
-	// Remove the ZIP and MD5 files from the attachment list
-	m_EmailMsg.RemoveAttachment(0);
-	m_EmailMsg.RemoveAttachment(0);
-
-	// Remove the recipient so that there will be no copies
-	m_EmailMsg.RemoveRecipient(0);
 
 	// Check status
     if(status==0)

--- a/reporting/crashsender/ErrorReportSender.cpp
+++ b/reporting/crashsender/ErrorReportSender.cpp
@@ -2075,6 +2075,13 @@ BOOL CErrorReportSender::SendReport()
     Utility::RecycleFile(m_sZipName, true);
     Utility::RecycleFile(m_sZipName+_T(".md5"), true);
 
+	// Remove the ZIP and MD5 files from the attachment list
+	m_EmailMsg.RemoveAttachment(0);
+	m_EmailMsg.RemoveAttachment(0);
+
+	// Remove the recipient so that there will be no copies
+	m_EmailMsg.RemoveRecipient(0);
+
 	// Check status
     if(status==0)
     {
@@ -2323,6 +2330,7 @@ BOOL CErrorReportSender::SendOverSMTP()
 
     // Send mail assynchronously
     int res = m_SmtpClient.SendEmailAssync(&m_EmailMsg, &m_Assync); 
+
     return (res==0);
 }
 

--- a/reporting/crashsender/smtpclient.cpp
+++ b/reporting/crashsender/smtpclient.cpp
@@ -84,6 +84,14 @@ CString CEmailMessage::GetRecipientAddress(int nRecipient)
 	return m_aTo[nRecipient];
 }
 
+void CEmailMessage::RemoveRecipient(int nRecipient) {
+	// Removes n-th recipient address
+	if (nRecipient >= (int)m_aTo.size() || nRecipient < 0) {
+		throw std::out_of_range("nRecipient out of range");
+	}
+	m_aTo.erase(m_aTo.begin() + nRecipient);
+}
+
 void CEmailMessage::AddAttachment(LPCTSTR szFileName)
 {
 	// Add file attachment.
@@ -100,6 +108,14 @@ CString CEmailMessage::GetAttachment(int nAttachment)
 {
 	// Return n-th attachment.
 	return m_aAttachments[nAttachment];
+}
+
+void CEmailMessage::RemoveAttachment(int nAttachment) {
+	// Removes n-th attachment.
+	if (nAttachment >= (int)m_aAttachments.size() || nAttachment < 0) {
+		throw std::out_of_range("nAttachment out of range");
+	}
+	m_aAttachments.erase(m_aAttachments.begin() + nAttachment);
 }
 
 CString CEmailMessage::GetText()

--- a/reporting/crashsender/smtpclient.h
+++ b/reporting/crashsender/smtpclient.h
@@ -52,6 +52,9 @@ public:
 
 	// Returns n-th recipient address
 	CString GetRecipientAddress(int nRecipient);
+	
+	// Adds a recipient address.
+	void RemoveRecipient(int nRecipient);
 
 	// Adds file attachment.
 	void AddAttachment(LPCTSTR szFileName);
@@ -61,6 +64,9 @@ public:
 
 	// Returns n-th attachment.
 	CString GetAttachment(int nAttachment);
+	
+	// Removes n-th attachment.
+	void RemoveAttachment(int nAttachment);
 
 	// Returns E-mail body.
 	CString GetText();


### PR DESCRIPTION
Copied from: https://sourceforge.net/p/crashrpt/code/merge-requests/4/

Fixed the earlier bugfix so that the attachments and recipients are removed only when sending via SMTP.

This version has been tested and it works now as it should. The earlier fix crashed when sending via HTTP and removing from empty attachments and recipients.